### PR TITLE
Enhancement Documentation

### DIFF
--- a/proto/sapphillon/v1/permission.proto
+++ b/proto/sapphillon/v1/permission.proto
@@ -1,27 +1,104 @@
 syntax = "proto3";
 
-//TODO Add more permission types and levels as needed
-
+// Defines permission primitives used to authorize operations across Sapphillon services.
+// First line is a concise summary (Google API style).
+//
+// Notes:
+// - Comments follow Google API style: third person, present tense; first sentence is a summary.
+// - Fields include behavior notes and example values when helpful.
+// - Resource names are free-form in this version; future revisions may introduce canonical patterns.
+//
+// TODO: Add more permission types and levels as needed.
 package sapphillon.v1;
 
+// Enumerates the type of action a permission authorizes.
+// Values:
+// - PERMISSION_TYPE_UNSPECIFIED: Default value. Do not use.
+// - PERMISSION_TYPE_READ: Grants read-only access to the resource.
+// - PERMISSION_TYPE_WRITE: Grants write or modify access to the resource.
+// - PERMISSION_TYPE_EXECUTE: Grants ability to execute or invoke the resource (e.g., run a workflow).
 enum PermissionType {
+  // Default value. Do not use.
   PERMISSION_TYPE_UNSPECIFIED = 0;
+
+  // Grants read-only access to the resource (e.g., fetch, list, inspect).
   PERMISSION_TYPE_READ = 1;
+
+  // Grants write or modify access to the resource (e.g., create, update, delete).
   PERMISSION_TYPE_WRITE = 2;
+
+  // Grants ability to execute or invoke the resource (e.g., run, trigger).
   PERMISSION_TYPE_EXECUTE = 3;
 }
 
+// Indicates the sensitivity or criticality level required for a permission.
+// The level may be used by policy engines, reviewers, or UI to require stronger approval.
+// Values:
+// - PERMISSION_LEVEL_UNSPECIFIED: Default value. Do not use.
+// - PERMISSION_LEVEL_MEDIUM: Standard operations with moderate impact.
+// - PERMISSION_LEVEL_HIGH: Operations with elevated risk or broader impact.
+// - PERMISSION_LEVEL_CRITICAL: Operations that can cause system-wide effects or data loss.
 enum PermissionLevel {
+  // Default value. Do not use.
   PERMISSION_LEVEL_UNSPECIFIED = 0;
+
+  // Standard operations with moderate impact.
   PERMISSION_LEVEL_MEDIUM = 1;
+
+  // Operations with elevated risk or broader impact.
   PERMISSION_LEVEL_HIGH = 2;
+
+  // Operations that can cause system-wide effects or data loss.
   PERMISSION_LEVEL_CRITICAL = 3;
 }
 
+// Describes a single permission requirement or grant for a specific resource.
+// Usage:
+// - Include in APIs (e.g., workflow or plugin definitions) to declare needed permissions.
+// - Use in policy evaluation to check whether a caller is authorized.
+//
+// Fields:
+// - display_name: Human-readable name shown in UIs (e.g., "Read File").
+// - description: Longer explanation of the permission's purpose.
+// - permission_type: Action category (read, write, execute).
+// - resource: Resource identifiers this permission applies to. Free-form in v1.
+// - permission_level: Sensitivity level to inform review and approval.
+//
+// Example:
+//   Permission {
+//     display_name: "Execute Workflow"
+//     description: "Runs the daily ETL pipeline"
+//     permission_type: PERMISSION_TYPE_EXECUTE
+//     resource: ["workflows/etl_daily"]
+//     permission_level: PERMISSION_LEVEL_HIGH
+//   }
+//
+// Field behavior notes:
+// - display_name: Recommended.
+// - description: Recommended.
+// - permission_type: Required.
+// - resource: Optional; when omitted applies broadly.
+// - permission_level: Recommended; some features may require it.
 message Permission {
+  // Human-readable name of the permission, suitable for display in UIs.
+  // Example: "Read File", "Execute Workflow".
   string display_name = 1;
+
+  // Detailed description of what the permission allows and when it is used.
+  // Keep concise but informative for reviewers and users.
   string description = 2;
+
+  // The action category this permission authorizes.
+  // Behavior: Required.
   PermissionType permission_type = 3;
-  repeated string resource = 4; // The resource this permission applies to, e.g., "file.txt"
+
+  // Resource identifiers this permission applies to.
+  // Format: Free-form strings in v1 (e.g., "file.txt", "workflows/etl_daily", "buckets/logs").
+  // Behavior: Optional. If empty, applies broadly and should be used with caution.
+  // Example: ["projects/proj-123/locations/us/workflows/etl_daily"]
+  repeated string resource = 4;
+
+  // The sensitivity or criticality level associated with this permission.
+  // Behavior: Recommended. Some approval flows may require a minimum level.
   PermissionLevel permission_level = 5;
 }

--- a/proto/sapphillon/v1/plugin.proto
+++ b/proto/sapphillon/v1/plugin.proto
@@ -5,23 +5,104 @@ package sapphillon.v1;
 import "google/protobuf/timestamp.proto";
 import "sapphillon/v1/permission.proto";
 
+// Describes a callable function exposed by a plugin.
+// A function declares its purpose, identity, and required permissions for execution.
+//
+// Fields:
+// - function_id: Stable unique identifier used by systems to reference the function.
+// - function_name: Human-friendly name suitable for UIs.
+// - description: Summary of what the function does and typical use cases.
+// - permissions: Permissions required for the caller to execute this function.
+//
+// Example:
+//   PluginFunction {
+//     function_id: "send_notification"
+//     function_name: "Send Notification"
+//     description: "Sends a message to a configured channel"
+//     permissions: [{ permission_type: PERMISSION_TYPE_EXECUTE, resource: ["channels/general"] }]
+//   }
 message PluginFunction {
-  string function_id = 1; // Unique identifier for the function
-  string function_name = 2; // Name of the function
-  string description = 3; // Description of what the function does
-  repeated Permission permissions = 4; // Permissions required to execute this function
+  // Stable unique identifier for the function.
+  // Behavior: Required. Must be unique within the plugin package.
+  string function_id = 1;
+
+  // Human-friendly display name of the function.
+  // Example: "Send Notification".
+  string function_name = 2;
+
+  // Short description of what the function does and when to use it.
+  string description = 3;
+
+  // Permissions required to execute this function successfully.
+  // Use Permission.resource to scope to specific entities as needed.
+  repeated Permission permissions = 4;
 }
 
+// Represents a plugin package that can be installed into the platform.
+// A plugin groups one or more functions and includes metadata useful for discovery and governance.
+//
+// Fields:
+// - package_id: Stable unique identifier of the plugin package.
+// - package_name: Human-friendly name of the plugin.
+// - package_version: Semantic version string (e.g., "1.2.3").
+// - description: Summary of the plugin's purpose and capabilities.
+// - functions: Functions exposed by this plugin.
+// - plugin_store_url: URL to the plugin page or documentation.
+// - internal_plugin: Indicates whether the plugin is internal-only.
+// - verified: Indicates whether the plugin is verified by the platform.
+//
+// - deprecated: Indicates whether the plugin is deprecated and should not be used for new workflows.
+// - installed_at: Time when the plugin was installed.
+// - updated_at: Time when the plugin was last updated.
+//
+// Example:
+//   PluginPackage {
+//     package_id: "com.example.notifications"
+//     package_name: "Notifications"
+//     package_version: "1.4.0"
+//     description: "Provides functions for sending notifications"
+//     plugin_store_url: "https://plugins.example.com/com.example.notifications"
+//     verified: true
+//     functions: [{ function_id: "send_notification", ... }]
+//   }
 message PluginPackage {
+  // Stable unique identifier for the plugin package.
+  // Behavior: Required; unique across all installed plugins.
   string package_id = 1;
+
+  // Human-friendly name of the plugin package.
+  // Example: "Notifications".
   string package_name = 2;
+
+  // Semantic version of the plugin package.
+  // Format: "MAJOR.MINOR.PATCH" (e.g., "1.0.3").
   string package_version = 3;
+
+  // Description of the plugin's purpose and capabilities.
   string description = 4;
+
+  // Functions exposed by this plugin.
   repeated PluginFunction functions = 5;
+
+  // URL to the plugin's store page or documentation.
+  // Example: "https://plugins.example.com/com.example.notifications".
   string plugin_store_url = 6;
+
+  // Whether this plugin is intended for internal use only.
+  // Behavior: Optional. Defaults to false when unset.
   optional bool internal_plugin = 7;
+
+  // Whether this plugin has been verified by the platform or publisher.
+  // Behavior: Optional. Defaults to false when unset.
   optional bool verified = 8;
+
+  // Whether this plugin is deprecated. New usage should be avoided.
+  // Behavior: Optional. When true, UIs should display warnings.
   optional bool deprecated = 9;
+
+  // Time when the plugin was installed.
   google.protobuf.Timestamp installed_at = 10;
+
+  // Time when the plugin metadata or package was last updated.
   google.protobuf.Timestamp updated_at = 11;
 }

--- a/proto/sapphillon/v1/version.proto
+++ b/proto/sapphillon/v1/version.proto
@@ -2,18 +2,37 @@ syntax = "proto3";
 
 package sapphillon.v1;
 
+// Provides read-only application version information.
+// The service returns semantic version strings for display and compatibility checks.
 service VersionService {
-  // Returns the current version of the application.
+  // Returns the current application version.
+  //
+  // Behavior:
+  // - Unary RPC.
+  // - Guaranteed to be fast and side-effect free.
+  // - Suitable for health checks or compatibility gating.
+  //
+  // Errors:
+  // - Typically none; may return INTERNAL if the version cannot be determined.
   rpc GetVersion(GetVersionRequest) returns (GetVersionResponse);
 }
 
+// Represents application version information.
+// The version string typically follows Semantic Versioning.
 message Version {
-  string version = 1; // The version of the application
+  // The version of the application.
+  // Format: "MAJOR.MINOR.PATCH" with optional pre-release or build metadata
+  // (e.g., "1.2.3", "1.2.3-beta.1", "1.2.3+build.45").
+  string version = 1;
 }
 
+// Request for GetVersion.
+// This message is intentionally empty to allow future extensibility without breaking changes.
 message GetVersionRequest {
-  // This message can be extended in the future if needed.
 }
+
+// Response for GetVersion.
 message GetVersionResponse {
-  Version version = 1; // The current version of the application
+  // The current application version.
+  Version version = 1;
 }

--- a/proto/sapphillon/v1/workflow.proto
+++ b/proto/sapphillon/v1/workflow.proto
@@ -5,47 +5,150 @@ package sapphillon.v1;
 import "google/protobuf/timestamp.proto";
 import "sapphillon/v1/permission.proto";
 
+// Enumerates supported workflow source languages.
+// Used to indicate the language of WorkflowCode.code.
 enum WorkflowLanguage {
+  // Default value. Do not use.
   WORKFLOW_LANGUAGE_UNSPECIFIED = 0;
+
+  // TypeScript source code.
   WORKFLOW_LANGUAGE_TYPESCRIPT = 1;
+
+  // JavaScript source code.
   WORKFLOW_LANGUAGE_JAVASCRIPT = 2;
 }
 
+// Represents a specific revision of workflow source code and metadata.
+//
+// Fields:
+// - id: Stable identifier of the workflow code entity.
+// - code_revision: Monotonic integer representing the code version within the workflow.
+// - code: The source code text.
+// - language: The language of the code.
+// - created_at: Timestamp when this code revision was created.
+// - result: Optional preview or last run result associated with this code revision.
+// - required_permissions: Permissions required to run this code (declared by the author).
+//
+// Notes:
+// - code_revision should increase by 1 for each new revision of the same workflow.
+// - required_permissions should be kept minimal and specific to support principle of least privilege.
 message WorkflowCode {
+  // Stable identifier of the workflow code entity.
   string id = 1;
+
+  // Monotonic integer representing the code version within the workflow.
+  // Behavior: Required. Starts at 1 and increments with each change.
   int32 code_revision = 2;
+
+  // The workflow source code.
   string code = 3;
+
+  // The programming language of the source code.
   WorkflowLanguage language = 4;
+
+  // Creation time of this code revision.
   google.protobuf.Timestamp created_at = 5;
+
+  // Optional result preview or cached output associated with this code revision.
+  // Behavior: Optional. May be empty when no run has occurred.
   optional string result = 6;
+
+  // Permissions required to execute this workflow code.
+  // Use specific Permission.resource values to scope access where possible.
   repeated sapphillon.v1.Permission required_permissions = 7;
 }
 
+// Classifies the outcome of a workflow execution.
+// Values:
+// - WORKFLOW_RESULT_TYPE_SUCCESS_UNSPECIFIED: Execution completed successfully.
+// - WORKFLOW_RESULT_TYPE_FAILURE: Execution failed (see exit_code and description).
 enum WorkflowResultType {
+  // Execution completed successfully.
   WORKFLOW_RESULT_TYPE_SUCCESS_UNSPECIFIED = 0;
+
+  // Execution failed.
   WORKFLOW_RESULT_TYPE_FAILURE = 1;
 }
 
-// TODO Add data types to properly represent the results
+// Captures the result of running a workflow at a specific code revision.
+//
+// Fields:
+// - id: Identifier of the result record.
+// - display_name: Human-friendly name for UIs (e.g., "Nightly Run 2025-08-05").
+// - description: Summary of the execution and relevant details.
+// - result: Raw result payload or textual summary.
+// - ran_at: Time the execution completed.
+// - result_type: Success or failure classification.
+// - exit_code: Process exit code when applicable (0 for success).
+// - workflow_code_revision: The code revision that produced this result.
+// - workflow_result_revision: Monotonic revision of this result record itself.
+//
+// TODO: Add structured data types for results (logs, metrics, artifacts).
 message WorkflowResult {
+  // Identifier of the result record.
   string id = 1;
+
+  // Human-friendly name for display.
   string display_name = 2;
+
+  // Summary of the execution and relevant details.
   string description = 3;
-  string result = 4; // The result of the workflow execution
+
+  // Raw result payload or textual summary of the run.
+  string result = 4;
+
+  // Time the execution completed.
   google.protobuf.Timestamp ran_at = 5;
+
+  // Success or failure classification.
   WorkflowResultType result_type = 6;
-  int32 exit_code = 7; // Exit code of the workflow execution
-  int32 workflow_code_revision = 8; // Revision of the workflow code that produced this result
-  int32 workflow_result_revision = 9; // Revision of the workflow result
+
+  // Process exit code when applicable (0 for success).
+  int32 exit_code = 7;
+
+  // Code revision that produced this result.
+  int32 workflow_code_revision = 8;
+
+  // Monotonic revision of this result record.
+  int32 workflow_result_revision = 9;
 }
 
+// Represents a workflow entity including its code history and execution results.
+//
+// Fields:
+// - id: Stable identifier for the workflow.
+// - display_name: Human-readable name.
+// - description: Purpose and summary of the workflow.
+// - workflow_language: Preferred or primary language used by this workflow.
+// - workflow_code: History of code revisions (latest may be last element or determined externally).
+// - created_at: Time the workflow was created.
+// - updated_at: Time the workflow was last modified.
+// - workflow_results: Historical execution results for this workflow.
+//
+// Notes:
+// - Keep workflow_code revisions append-only to preserve history.
 message Workflow {
+  // Stable identifier for the workflow.
   string id = 1;
+
+  // Human-readable name for the workflow.
   string display_name = 2;
+
+  // Description of the workflow's purpose and behavior.
   string description = 3;
+
+  // Preferred or primary language used by this workflow.
   WorkflowLanguage workflow_language = 4;
+
+  // History of workflow code revisions.
   repeated WorkflowCode workflow_code = 5;
+
+  // Creation time of the workflow.
   google.protobuf.Timestamp created_at = 6;
+
+  // Last update time of the workflow.
   google.protobuf.Timestamp updated_at = 7;
+
+  // Historical execution results for this workflow.
   repeated WorkflowResult workflow_results = 8;
 }

--- a/proto/sapphillon/v1/workflow_service.proto
+++ b/proto/sapphillon/v1/workflow_service.proto
@@ -2,50 +2,75 @@ syntax = "proto3";
 
 package sapphillon.v1;
 
-// Service for generating structured workflows.
+// Generates and fixes structured workflow definitions from natural language descriptions.
+// Methods stream partial outputs to allow progressive rendering in UIs and long-running processing.
 service WorkflowService {
-  // Generates a workflow based on a natural language prompt.
-  // This is a custom method that takes a text prompt and returns
-  // a structured workflow definition.
+  // Generates a workflow from a natural language prompt.
+  //
+  // Behavior:
+  // - Server-streaming RPC that emits partial or incremental workflow definitions.
+  // - The client should read until the stream completes to obtain the final definition.
+  //
+  // Responses:
+  // - Each message may represent a partial draft or an updated full definition.
+  //
+  // Errors:
+  // - INVALID_ARGUMENT if the prompt is empty or malformed.
+  // - INTERNAL for unexpected generation errors.
   rpc GenerateWorkflow(GenerateWorkflowRequest) returns (stream GenerateWorkflowResponse);
 
-  // Fixes an existing workflow definition based on a description of issues.
-  // This method takes a workflow definition and a description of the issues
-  // and returns a fixed workflow definition.
+  // Fixes an existing workflow definition using a description of issues.
+  //
+  // Behavior:
+  // - Server-streaming RPC that emits suggested fixes and updated definitions incrementally.
+  // - The final message in the stream typically represents the fully fixed definition.
+  //
+  // Errors:
+  // - INVALID_ARGUMENT if workflow_definition or description is empty.
+  // - FAILED_PRECONDITION if the definition cannot be parsed.
+  // - INTERNAL for unexpected processing errors.
   rpc FixWorkflow(FixWorkflowRequest) returns (stream FixWorkflowResponse);
 }
 
-// Request message for generating a workflow.
+// Request to generate a workflow from a natural language prompt.
 message GenerateWorkflowRequest {
-  // The natural language prompt describing the desired workflow.
-  // e.g., "Check the weather, and if it's raining, send me a notification."
+  // Natural language prompt describing the desired workflow.
+  // Example: "Check the weather, and if it's raining, send me a notification."
+  // Behavior: Required; must be non-empty.
   string prompt = 1;
 }
 
-// Response message containing the generated workflow.
+// Server-streamed response containing the generated workflow definition.
+// Each streamed message may be partial; the client should merge or replace as appropriate.
 message GenerateWorkflowResponse {
-  // The structured workflow definition.
-  // The format of this definition can be JSON, YAML, or another
-  // structured format, represented as a string.
+  // Structured workflow definition.
+  // Format: String-encoded structure such as JSON or YAML.
+  // Example (JSON):
+  //   {"steps":[{"id":"check_weather"},{"id":"notify","if":"raining"}]}
   string workflow_definition = 1;
 }
 
+// Request to fix a workflow definition using a problem description.
 message FixWorkflowRequest {
   // The workflow definition to be fixed.
-  // This should be a structured format like JSON or YAML.
+  // Format: JSON, YAML, or another structured text representation.
+  // Behavior: Required; must be parseable by the service.
   string workflow_definition = 1;
 
-  // A description of the issues to fix.
-  // This can help guide the fixing process.
+  // Description of issues to fix or constraints to apply.
+  // Example: "Step IDs must be unique; add retry to notification step."
+  // Behavior: Required; must be non-empty.
   string description = 2;
 }
 
+// Server-streamed response carrying fixed workflow definitions and a change summary.
+// The final message typically represents the complete fixed definition.
 message FixWorkflowResponse {
   // The fixed workflow definition.
-  // This should be a structured format like JSON or YAML.
+  // Format: JSON, YAML, or another structured text representation.
   string fixed_workflow_definition = 1;
 
-  // A summary of the changes made to fix the workflow.
-  // This can help users understand what was changed.
+  // Summary of changes applied to produce the fixed definition.
+  // Example: "Renamed duplicate step IDs; added retry policy to 'notify'."
   string change_summary = 2;
 }


### PR DESCRIPTION
This pull request updates the Sapphillon service protobuf definitions to provide more comprehensive documentation, clarify field behavior, and improve API usability. The changes focus on enhancing comments and descriptions, standardizing field usage, and introducing additional structure for permissions, plugins, workflows, and versioning. The most important changes are grouped below:

**Permissions and Authorization Enhancements:**
* Expanded and clarified the `PermissionType` and `PermissionLevel` enums in `permission.proto`, with detailed comments, usage notes, and field behavior guidance. Added comprehensive documentation for the `Permission` message, including field recommendations and examples.

**Plugin API Improvements:**
* Added extensive documentation to the `PluginFunction` and `PluginPackage` messages in `plugin.proto`, specifying field purposes, behavior, and examples. Improved clarity on plugin metadata, permissions, and lifecycle fields.

**Workflow and Workflow Service Updates:**
* Documented the `WorkflowLanguage` enum and all workflow-related messages in `workflow.proto`, providing detailed field descriptions and usage notes for `WorkflowCode`, `WorkflowResult`, and `Workflow`. Clarified the purpose and expected usage of each field.
* Enhanced the `WorkflowService` API in `workflow_service.proto` with detailed comments on streaming RPCs (`GenerateWorkflow`, `FixWorkflow`), request/response message structures, error handling, and field requirements.

**Version Service Documentation:**
* Added comments to `version.proto` describing the `VersionService`, request/response messages, and the `Version` message format, including semantic versioning details and error behavior.