### PR TITLE
feat: Disable direct workflow definition in RunWorkflow API

### DIFF
--- a/proto/sapphillon/v1/workflow_service.proto
+++ b/proto/sapphillon/v1/workflow_service.proto
@@ -108,7 +108,7 @@ message FixWorkflowResponse {
   google.rpc.Status status = 3;
 }
 
-// Request to run a workflow by ID or by providing a definition.
+// Request to run a workflow by ID.
 message RunWorkflowRequest {
   // Run a workflow by its ID and code ID.
   WorkflowSourceById by_id = 1;


### PR DESCRIPTION
Removes the ability to run a workflow by directly providing its definition in the `RunWorkflow` API call.

The `workflow_definition` field has been removed from the `RunWorkflowRequest` message, and the field number and name have been reserved to prevent future reuse.