### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       bump-type:
         description: 'Bump type'
         required: true
+        type: choice
         options:
           - major
           - minor


### PR DESCRIPTION
Adds a new GitHub Actions workflow to automate the release process.

The workflow is triggered manually and allows the user to specify the version increment (patch, minor, or major) and whether the release should be marked as a pre-release.

It uses the anothrNick/github-tag-action to automatically bump the version and create a Git tag, and the actions/create-release action to create a GitHub Release.

#43 