### PR TITLE
Fix GitHub Release workflow authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,4 @@ jobs:
             ${{ github.event.inputs.generate-notes && '--generate-notes' || '' }} \
             ${{ github.event.inputs.prerelease && '--prerelease' || '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated `.github/workflows/release.yml` to use `GH_TOKEN` instead of `GITHUB_TOKEN` for the "Create GitHub Release" step, as required by the GitHub CLI.