### PR TITLE
Fix GitHub Release workflow inputs and authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,8 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
-          release_type: ${{ github.event.inputs.bump-type }}
-          default_branch: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: ${{ github.event.inputs.bump-type }}
 
       - name: Create GitHub Release
         run: |


### PR DESCRIPTION
Updated `.github/workflows/release.yml` to:
1. Fix inputs for `mathieudutour/github-tag-action@v6.1` by renaming `release_type` to `default_bump`, removing invalid `default_branch`, and adding the required `github_token`.
2. Use `GH_TOKEN` environment variable for `gh release create` command authentication.