### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_protobuf.yml
+++ b/.github/workflows/check_protobuf.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   check-proto:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Sapphillon/Sapphillon_API/security/code-scanning/1](https://github.com/Sapphillon/Sapphillon_API/security/code-scanning/1)

The fix is to explicitly set the `permissions` key for the affected job or at the workflow root. The job here named `check-proto` must only request the permissions it needs. From inspection, all steps are local shell scripts (checkout code, download a CLI binary, lint and format proto files), so the minimal required permission is `contents: read`. No steps push back changes, create issues, or manipulate PRs. The best practice is to set `permissions: contents: read` at the job level (`check-proto`) so that the job GITHUB_TOKEN operates with minimal privileges, adhering to the least privilege principle. Edit the `.github/workflows/check_protobuf.yml` file, adding the following block beneath the job name, indented to match the existing YAML structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
